### PR TITLE
feat: Add OSSAfrica Special Interest Group and update working group references from DEI to BEAR.

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -14,7 +14,7 @@ This Technical Charter sets forth the responsibilities and procedures for techni
 
 ### 2. Technical initiative roles
 
-(a) The primary points of contact are the lead and co-lead(s) of the Technical Initiative, who are listed in the [README](https://github.com/ossf/wg-dei/blob/main/README.md#governance)
+(a) The primary points of contact are the lead and co-lead(s) of the Technical Initiative, who are listed in the [README](https://github.com/ossf/wg-bear/blob/main/README.md#governance)
 
 (b) The Technical Initiative generally will involve Collaborators and Contributors. The Technical Initiative may adopt or modify additional roles so long as the roles are documented in the Technical Initiative’s repository. Unless otherwise documented:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We value all contributions, from improving documentation to participating in dis
 
 ### 2. Report Issues or Suggest Enhancements
 
-- Use the [GitHub Issues](https://github.com/ossf/wg-dei/issues) tab to report problems or suggest ideas.
+- Use the [GitHub Issues](https://github.com/ossf/wg-bear/issues) tab to report problems or suggest ideas.
 - Follow our issue template to provide clear and detailed information.
 
 ### 3. Submit Pull Requests
@@ -47,6 +47,6 @@ We are committed to maintaining a welcoming, inclusive, and respectful environme
 - **Be Collaborative:** Work together to solve problems and build new initiatives.
 - **Be Open:** Share your knowledge and be open to learning from others.
 
-We’re excited to collaborate with you and appreciate your support in advancing DEI in open source cybersecurity!
+We’re excited to collaborate with you and appreciate your support in advancing beloging, empowerment, allyship, and representation in open source cybersecurity!
 
 For any questions or additional guidance, contact us through Slack or during our working group meetings. Let's build a better, more inclusive cybersecurity community together!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,6 @@ We are committed to maintaining a welcoming, inclusive, and respectful environme
 - **Be Collaborative:** Work together to solve problems and build new initiatives.
 - **Be Open:** Share your knowledge and be open to learning from others.
 
-We’re excited to collaborate with you and appreciate your support in advancing beloging, empowerment, allyship, and representation in open source cybersecurity!
+We’re excited to collaborate with you and appreciate your support in advancing belonging, empowerment, allyship, and representation in open source cybersecurity!
 
 For any questions or additional guidance, contact us through Slack or during our working group meetings. Let's build a better, more inclusive cybersecurity community together!

--- a/MMYY-office-hours-recap-template.md
+++ b/MMYY-office-hours-recap-template.md
@@ -24,4 +24,4 @@ Visit OpenSSF BEAR Working Group
 - **Attend Public Call:** Every 2 weeks, Tuesday 11am EST. The meeting invite is available on the [public OSSF calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
 - **Slack Channel:** Join the conversation on our #wg-bear [OpenSSF Slack channel](#https://openssf.slack.com/join/shared_invite/zt-2sa4ub3pw-TKfiwHzTINSQY4ZSunhnSw#/shared-invite/email). This is the best place to ask questions, share ideas, and collaborate.
 - **Community Office Hours:** Missed a Community Office Hours session? Watch past sessions on our [YouTube Playlist](#https://youtube.com/playlist?list=PLVl2hFL_zAh-5YC3PnIbc14KDEYsgLYBs&si=aTFpeeRCgA4KNjn9). Stay informed, learn from discussions, and catch up on important updates.
-- **GitHub Repo:** Want to contribute? Check out our latest updates in our [Github Repo](https://github.com/ossf/wg-dei)
+- **GitHub Repo:** Want to contribute? Check out our latest updates in our [Github Repo](https://github.com/ossf/wg-bear)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Every 2 weeks, Tuesday 11am EST. The meeting invite is available on the [public 
 2. [Yesenia Yser](https://github.com/Cyber-JiuJiteria) (Microsoft)
 3. [Jay White](https://github.com/camaleon2016) (Microsoft)
 
+### Special Interest Groups
+
+#### Open Source & Security Africa (OSSAfrica)
+
+Focused on open source collaboration and software security across Africa.
+
+* **Leads**: [Prince Oforh Asiedu](https://github.com/PrinceAsiedu), [Seth Mensah](https://github.com/iamcerebrocerberus), [Aaron Will Djaba](https://github.com/kurtiz)
+* **Governing Body**: OpenSSF BEAR Working Group
+* **Resources**: [GitHub Organization](https://github.com/OSSAfrica)
+
 ### Roadmap
 
 To get an idea of our annual goals, our [roadmap](./Roadmap.md) covers
@@ -49,10 +59,10 @@ Anyone is welcome to join our open discussions related to the group's mission an
 
 #### Communication Channels
 
-* Official communications occur on the BEAR Working Group [mailing list](https://lists.openssf.org/g/openssf-wg-dei)
+* Official communications occur on the BEAR Working Group [mailing list](https://lists.openssf.org/g/openssf-wg-bear)
 * Manage your subscriptions to [Open SSF mailing lists](https://lists.openssf.org/g/main/subgroups)
 * Join the conversation on [Slack](https://app.slack.com/client/T019QHUBYQ3/C068TF7AH0U)
-* Explore the [GitHub Issues](https://github.com/ossf/wg-dei/issues) to collaborate.
+* Explore the [GitHub Issues](https://github.com/ossf/wg-bear/issues) to collaborate.
 
 ### Meeting Archive
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,4 +1,4 @@
-# OpenSSF DEI WG Roadmap
+# OpenSSF BEAR WG Roadmap
 
 The WG is planning for the following focus areas and activities.
 


### PR DESCRIPTION
This PR adds the "Open Source & Security Africa (OSSAfrica)" Special Interest Group (SIG) to the README.md
file and modifies references to former DEI naming to BEAR.

Changes:

Added a new Special Interest Groups section under Working Group Info in README.md.

Documented the OSSAfrica SIG with the following details:
Mission: Focused on open source collaboration and software security across Africa.
Leads: Prince Oforh Asiedu, Seth Mensah, Aaron Will Djaba.
Resources: Link to the OSSAfrica GitHub organization.